### PR TITLE
feat: Enable float handling for AWP number sensor

### DIFF
--- a/custom_components/goecharger_api2/const.py
+++ b/custom_components/goecharger_api2/const.py
@@ -271,6 +271,7 @@ NUMBER_SENSORS = [
     # awp -> this is in €-CENT! - but api allow to specify 0.01 cent steps
     ExtNumberEntityDescription(
         key=Tag.AWP.key,
+        handle_as_float=True,
         native_max_value=1000,
         native_min_value=-100,
         native_step=0.01,


### PR DESCRIPTION
Implements issue #69 by letting the `awp` number entity pass fractional limits straight through to the go‑eCharger.
With the `handle_as_float` flag we keep the Home Assistant value as a float right up to the bridge, so it’s serialized as a quoted string in the HTTP call. Confirmed in debug logs: the integration sends `{'awp': '7.74'}` and the charger responds with `{'awp': 7.74}`, which shows up in the app without any delay.

```
2025-10-20 11:38:12.475 INFO (MainThread) [custom_components.goecharger_api2.pygoecharger_ha] going to write {'awp': '7.74'} to go-eCharger@http://go-e.home
2025-10-20 11:38:12.522 DEBUG (MainThread) [custom_components.goecharger_api2] write result: {'awp': 7.74}
```