### PR TITLE
Fix connection resets by chunking large API requests

### DIFF
--- a/custom_components/goecharger_api2/pygoecharger_ha/const.py
+++ b/custom_components/goecharger_api2/pygoecharger_ha/const.py
@@ -22,8 +22,12 @@ FILTER_IDS_ADDON: Final = ",pakku,ppv,pgrid"
 # rbt: is the reboot time - and "looks like", that all other timestamps use the rbt "as" start point
 FILTER_TIMES_ADDON: Final = ",rbt,fsptws,inva,lbp,lccfc,lccfi,lcctc,lfspt,lmsc,lpsc,lcs"
 
-FILTER_ALL_STATES: Final = "alw,acu,adi,amt,atp,awcp,car,{CARDS_ENERGY_FILTER},cbl,ccu,ccw,cdi,cll,cus,ctrls,deltaa,deltap,di1,err,eto,ffb,fhz,fsp,fsptws,inva,lbp,lccfc,lccfi,lcctc,lck,lfspt,lmsc,loa,lpsc,mcpea,mmp,modelStatus,nif,nrg,pakku,pgrid,pha,pnp,ppv,pvopt_averagePAkku,pvopt_averagePGrid,pvopt_averagePPv,pwm,rbc,rbt,rfb,rssi,rst,tlf,tls,tma,tpa,trx,wh,wsms,wst"
-FILTER_ALL_CONFIG: Final = "acp,acs,ama,amp,ara,ate,att,awc,awe,awp,bac,{CARDS_ID_FILTER},cch,cco,cfi,cid,clp,cmse,ct,cwc,cwe,dwo,esk,fmt,fna,frc,frm,fst,fup,fzf,hsa,lbr,lmo,loe,lof,log,lop,lot,loty,lse,map,mca,mci,mcpd,mptwt,mpwst,nmo,pgt,po,psh,psm,psmd,rdbf,rdbs,rdef,rdes,rdre,rdpl,sch_satur,sch_sund,sch_week,sdp,sh,spl3,su,sua,sumd,tds,tof,upo,ust,zfo"
+FILTER_ALL_STATES_1: Final = "alw,acu,adi,amt,atp,awcp,car,{CARDS_ENERGY_FILTER},cbl,ccu,ccw,cdi,cll,cus,ctrls,deltaa,deltap,di1,err,eto,ffb,fhz,fsp,fsptws,inva,lbp,lccfc"
+FILTER_ALL_STATES_2: Final = "lccfi,lcctc,lck,lfspt,lmsc,loa,lpsc,mcpea,mmp,modelStatus,nif,nrg,pakku,pgrid,pha,pnp,ppv,pvopt_averagePAkku,pvopt_averagePGrid,pvopt_averagePPv,pwm,rbc,rbt,rfb,rssi,rst,tlf,tls,tma,tpa,trx,wh,wsms,wst"
+FILTER_ALL_STATES: Final = [FILTER_ALL_STATES_1, FILTER_ALL_STATES_2]
+FILTER_ALL_CONFIG_1: Final = "acp,acs,ama,amp,ara,ate,att,awc,awe,awp,bac,{CARDS_ID_FILTER},cch,cco,cfi,cid,clp,cmse,ct,cwc,cwe,dwo,esk"
+FILTER_ALL_CONFIG_2: Final = "fmt,fna,frc,frm,fst,fup,fzf,hsa,lbr,lmo,loe,lof,log,lop,lot,loty,lse,map,mca,mci,mcpd,mptwt,mpwst,nmo,pgt,po,psh,psm,psmd,rdbf,rdbs,rdef,rdes,rdre,rdpl,sch_satur,sch_sund,sch_week,sdp,sh,spl3,su,sua,sumd,tds,tof,upo,ust,zfo"
+FILTER_ALL_CONFIG: Final = [FILTER_ALL_CONFIG_1, FILTER_ALL_CONFIG_2]
 
 FILTER_NOT_USED: Final = "mcc,mcca,mce,mcr,mcs,mcu,men,mlr,mlra,mqcn,mqg,mqss,msb,msp,msr,mtp,ocppai,ocppi,rdbfe,rdbse,rdefe,rdese,rdree,rdple"
 


### PR DESCRIPTION
Within the last couple of weeks, I started getting issues with integration instability. It did not totally fail all the time, and it _might_ have occurred more frequently if the car was connected to the charger.

Anyways, logs were filling with frequent `ClientOSError: [Errno 104] Connection reset by peer` and `ServerDisconnectedError` warnings.

### Changes

1.  **Chunked API Requests**: The `read_all_config` and `read_all_states` methods now fetch data in two smaller chunks instead of single massive requests.
    * The go-eCharger API appears to drop connections when the `filter` query parameter exceeds a certain length or key count. Splitting these requests clearly helped. AFAIK, this could be an intentional URL length/request size limitation in the server logic or simply hitting server resource limits.
    * Updated code to support `FILTER_ALL_CONFIG` and `FILTER_ALL_STATES` as lists of strings, enabling the chunking logic.

2.  **Reduce log spam from connection problems**:
    *   Added retry logic (3 attempts) to `read_versions` to handle transient connection failures during startup.
    *   Added a 5-minute backoff mechanism to `read_all_config` to prevent continuous polling loops if the device is unresponsive.
