### PR TITLE
Fix API links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ If you have any issues with this integration after you updated your go-eCharger 
  
 ### go-eCharger
 
- - __All documented fields__ [in the official go-eCharger GitHub repository](https://github.com/goecharger/go-eCharger-API-v2/blob/main/apikeys-en.md) are supported by this integration (with very few exceptions) [[see list of currently not handled API keys](#list-of-currently-not-handled-api-keys-27172)]
+ - __All documented fields__ [in the official go-eCharger GitHub repository](https://github.com/goecharger/go-eCharger-API-v2/blob/main/API_KEYS_FIRMWARE/apikeys-en.md
+) are supported by this integration (with very few exceptions) [[see list of currently not handled API keys](#list-of-currently-not-handled-api-keys-27172)]
  - Support for 'PV surplus charging' (PV-Überschuss Laden) __without additional hardware__ — no need to pay for evcc. In order to use this feature, a small additional manual setup process is required [[details can be found below](#enable-pv-surplus-charging-via-ha-automation)]
  - For all go-eCharger (status) fields that support a numeric status code, this code is available as a separate sensor
  - Multilanguage support: a German translation included (any feedback highly appreciated!) & looking forward to other language contributions
@@ -54,7 +55,7 @@ If you have any issues with this integration after you updated your go-eCharger 
 - Owners of a 22kW variant can __force 16A only__ for all relevant settings. (This can be enabled via the integration settings and require a restart of the integration — then with every restart the settings will be inspected and adjusted to a max of 16A if required)
 
 ### go-eController
- - This integration [supports __most documented fields__ in the official go-eCharger GitHub repository](https://github.com/goecharger/go-eCharger-API-v2/blob/main/apikeys-en.md).
+ - This integration [supports __most documented fields__ in the official go-eCharger GitHub repository](https://github.com/goecharger/go-eCharger-API-v2/blob/main/API_KEYS_FIRMWARE/apikeys-en.md).
  - More sensors will follow up
  - Multilanguage support: a German translation included (any feedback highly appreciated!) & looking forward to other language contributions
 
@@ -303,7 +304,7 @@ Please consider [using my personal Tibber invitation link to join Tibber today](
 
 ### References
 
-- https://github.com/goecharger/go-eCharger-API-v2/blob/main/apikeys-en.md
+- https://github.com/goecharger/go-eCharger-API-v2/blob/main/API_KEYS_FIRMWARE/apikeys-en.md
 - https://github.com/goecharger/go-eController-API/blob/main/apikeys-en.md
 
 [^1]: `focore` stands for: **fo**rce **co**nfiguration **re**quest

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ If you have any issues with this integration after you updated your go-eCharger 
  
 ### go-eCharger
 
- - __All documented fields__ [in the official go-eCharger GitHub repository](https://github.com/goecharger/go-eCharger-API-v2/blob/main/API_KEYS_FIRMWARE/apikeys-en.md
-) are supported by this integration (with very few exceptions) [[see list of currently not handled API keys](#list-of-currently-not-handled-api-keys-27172)]
+ - __All documented fields__ [in the official go-eCharger GitHub repository](https://github.com/goecharger/go-eCharger-API-v2/blob/main/API_KEYS_FIRMWARE/apikeys-en.md) are supported by this integration (with very few exceptions) [[see list of currently not handled API keys](#list-of-currently-not-handled-api-keys-27172)]
  - Support for 'PV surplus charging' (PV-Überschuss Laden) __without additional hardware__ — no need to pay for evcc. In order to use this feature, a small additional manual setup process is required [[details can be found below](#enable-pv-surplus-charging-via-ha-automation)]
  - For all go-eCharger (status) fields that support a numeric status code, this code is available as a separate sensor
  - Multilanguage support: a German translation included (any feedback highly appreciated!) & looking forward to other language contributions


### PR DESCRIPTION
I noticed that the API links were moved on the go-E side so here's my proposed change to fix that in this repo.