### PR TITLE
Fix incorrect fr translation of locked cable

### DIFF
--- a/custom_components/goecharger_api2/translations/fr.json
+++ b/custom_components/goecharger_api2/translations/fr.json
@@ -249,7 +249,7 @@
         "state": {
           "0": "Mode standard",
           "1": "Déverrouillage auto",
-          "2": "Toujours déverrouillé",
+          "2": "Toujours verrouillé",
           "3": "Forcer déverrouillage"
         }
       },


### PR DESCRIPTION
It say "toujours deverouillé" in ust state 2,  (alaway unlock), but it's alaway lock "toujours verouillé"